### PR TITLE
Added instructions for cloning cartogram-web

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,13 @@ The first time you run this command it may take a while to download and install 
 
 ## Local development and testing
 
-To start the go-cart.io web application for local development and testing, you will need to clone `cartogram-web` repository from https://github.com/go-cart-io/cartogram-web and put it inside `cartogram-docker`. The project stucture should be as follow:
+To start the go-cart.io web application for local development and testing, you will need to clone `cartogram-web` repository from https://github.com/go-cart-io/cartogram-web and put it inside `cartogram-docker`. You may do so by running the following command inside the `cartogram-docker` repository:
+
+```
+git clone https://github.com/go-cart-io/cartogram-web.git
+```
+
+The project stucture should now look like so:
 
 ```
 cartogram-docker


### PR DESCRIPTION
Now users can easily do everything from this page. Ideally, we would change this to a submodule in the future (so they are more connected rather than the user just cloning the repository).