### PR TITLE
Make cartogram-web a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cartogram-web"]
+	path = cartogram-web
+	url = https://github.com/go-cart-io/cartogram-web

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 This repository contains a Docker compose file that makes it easy to install and run go-cart.io website. Steps to run the application is as follow:
 
 1. [Install Docker and Docker Compose](docs/docker.md).
-2. Clone this repository.
+2. Clone this repository. When cloning this repository, make sure to use the `--recurse-submodules` flag like so:
 
 ```shell script
-$ git clone https://github.com/go-cart-io/cartogram-docker.git
+$ git clone --recurse-submodules https://github.com/go-cart-io/cartogram-docker.git
 ```
 
 3. Copy `password.txt.dist` to `password.txt` and `.env.dist` to `.env`. You may modify the content in the files as needed.

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ This repository contains a Docker compose file that makes it easy to install and
 2. Clone this repository. When cloning this repository, make sure to use the `--recurse-submodules` flag like so:
 
 ```shell script
-$ git clone --recurse-submodules https://github.com/go-cart-io/cartogram-docker.git
+git clone --recurse-submodules https://github.com/go-cart-io/cartogram-docker.git
 ```
 
 3. Copy `password.txt.dist` to `password.txt` and `.env.dist` to `.env`. You may modify the content in the files as needed.
 4. Run the following command from the root directory of this repository (i.e., the folder containing this readme).
 
 ```shell script
-cartogram-docker$ docker-compose up -d
+docker-compose up -d
 ```
 
 The first time you run this command it may take a while to download and install dependencies. You can access the locally-running go-cart.io website at http://localhost:5001.
@@ -70,15 +70,15 @@ You need to install [Node.js](https://nodejs.org), then run the following comman
 
 ```shell script
 # After install Nodejs
-cartogram-docker$ cd cartogram-web/frontend
-cartogram-docker/cartogram-web/frontend$ npm install
-cartogram-docker/cartogram-web/frontend$ npm run dev
+cd cartogram-web/frontend
+npm install
+npm run dev
 ```
 
 Then, open anoter terminal and run the following command from the root directory of this repository (i.e., the folder containing this readme):
 
 ```shell script
-cartogram-docker$ docker-compose --profile web up -d
+docker-compose --profile web up -d
 ```
 
 After all of the Docker containers have started up, all of their output will be collected into the terminal window so you can see how the web application is responding to requests, and if it encounters any errors. You can access the locally-running go-cart.io website at http://localhost:5001.
@@ -121,15 +121,15 @@ Please follow this tutorial https://developer.chrome.com/docs/devtools/remote-de
 Run the following command:
 
 ```shell script
-cartogram-docker/cartogram-web/frontend$ npm run build
-cartogram-docker$ docker-compose build web
+npm run build
+docker-compose build web
 ```
 
 You should found updated frontend code in `internal/static/dist`. The docker image should be updated with new code. You may also want to push docker image into docker repository.
 
 ```shell script
-cartogram-docker$ docker login
-cartogram-docker$ docker push gocartio/cartogram-web:latest
+docker login
+docker push gocartio/cartogram-web:latest
 ```
 
 # Contact

--- a/README.md
+++ b/README.md
@@ -20,12 +20,6 @@ The first time you run this command it may take a while to download and install 
 
 ## Local development and testing
 
-To start the go-cart.io web application for local development and testing, you will need to clone `cartogram-web` repository from https://github.com/go-cart-io/cartogram-web and put it inside `cartogram-docker`. You may do so by running the following command inside the `cartogram-docker` repository:
-
-```
-git clone https://github.com/go-cart-io/cartogram-web.git
-```
-
 The project stucture should now look like so:
 
 ```
@@ -36,6 +30,7 @@ cartogram-docker
 │   ├── ...
 ├── docs
 ├── .env
+├── password.txt
 ├── docker-compose.yml
 ├── docker-compose-dev.yml
 ├── ...


### PR DESCRIPTION
Now, cartogram-web will always be cloned with cartogram-docker when you use the `--recurse-submodules` flag. I've updated the instructions accordingly. 

I've also removed all dollar signs in the command input. As I mentioned in my commit:
> Dollar signs make it much tougher to just copy and paste instructions.They are also not recommended practice, and the default VSCode style linter points this out.